### PR TITLE
Add csv parser validation logic on client side

### DIFF
--- a/src/components/tag/Tags.tsx
+++ b/src/components/tag/Tags.tsx
@@ -22,7 +22,7 @@ interface StatePropsInterface {
 }
 
 interface DispatchPropsInterface {
-  uploadTags: (formData: FormData) => void;
+  uploadTags: (payload: { tags: string[] }) => void;
   fetchTags: (pageParams: PageParams) => void;
 }
 
@@ -48,9 +48,9 @@ const TagsPage = (props: InjectedProps) => {
     navigate(path);
   };
 
-  const onUpload = async (formData: FormData) => {
+  const onUpload = async (tags: string[]) => {
     try {
-      await uploadTags(formData);
+      await uploadTags({ tags });
       toast.success('File Uploaded successfully');
     } catch (err) {
       toast.error('Unable to upload file');
@@ -63,7 +63,7 @@ const TagsPage = (props: InjectedProps) => {
     <>
       <div className="container w-100">
         <FileUploader
-          fileSizeLimit={60000}
+          csvKeyCountLimit={100}
           allowedMimeTypes={['text/csv']}
           isLoading={isLoadingUploadTags}
           onUpload={onUpload}

--- a/src/services/tags.ts
+++ b/src/services/tags.ts
@@ -1,5 +1,5 @@
 import config from '../config';
-import http, { httpFile } from '../utils/http';
+import http from '../utils/http';
 import * as qs from '../utils/queryString';
 import { PageParams } from '../types/Pagination';
 
@@ -11,9 +11,9 @@ export async function getTags(pageParams: PageParams) {
   return data;
 }
 
-export async function uploadTags(file: FormData) {
+export async function uploadTags(payload: { tags: string[] }) {
   const url = config.endpoints.uploadTags;
-  const { data } = await httpFile.post(url, file);
+  const { data } = await http.post(url, payload);
 
   return data;
 }


### PR DESCRIPTION
## Description
Since, in the requirements we have a limitation of 100 words of csv file. It is safe to handle the parsing from the client side. In previous implementation we were assuming all the services to be on same computation device which will not be the case. So, updated the logic of handling csv files and implementation of validation from the client side.

## Issue
#9 